### PR TITLE
Move AutoShark label underneath connect button

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -40,7 +40,6 @@ const Menu = (props) => {
       cakePriceUsd={zombiePrice}
       links={config(t)}
       subLinks={activeMenuItem?.hideSubNav ? [] : activeMenuItem?.items}
-      footerLinks={footerLinks(t)}
       activeItem={activeMenuItem?.href}
       activeSubItem={activeSubMenuItem?.href}
       hr

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { CurrencyAmount, JSBI, Token, Trade } from '@autoshark-finance/sdk'
-import { Button, Text, ArrowDownIcon, Box, useModal } from '@pancakeswap/uikit'
+import { Button, Text, ArrowDownIcon, Box, useModal, Link } from '@pancakeswap/uikit'
 import { useIsTransactionUnsupported } from 'hooks/Trades'
 import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'
 import { RouteComponentProps } from 'react-router-dom'
@@ -487,6 +487,16 @@ export default function Swap({ history }: RouteComponentProps) {
               </Column>
             )}
             {isExpertMode && swapErrorMessage ? <SwapCallbackError error={swapErrorMessage} /> : null}
+            <Button
+              as="a"
+              variant="subtle"
+              width="100%"
+              mt="4px"
+              external
+              href="https://docs.autoshark.finance/resources/swap-as-a-service-integration"
+            >
+              Powered by AutoShark
+            </Button>
           </Box>
         </Wrapper>
       </AppBody>


### PR DESCRIPTION
Here's a screenshot of the change. The link goes to [this page](https://docs.autoshark.finance/resources/swap-as-a-service-integration)

![Screenshot 2022-01-11 234754](https://user-images.githubusercontent.com/37122448/149071127-4bacff76-5851-4fed-90c3-07ad9c0ec410.png)

I also removed the label from the footer:
![Screenshot 2022-01-11 235053](https://user-images.githubusercontent.com/37122448/149071509-4f0526e0-4142-49f2-9562-3084f595875b.png)